### PR TITLE
remove unneeded calls to getStoreAndLocaleKey

### DIFF
--- a/src/Spryker/Service/Synchronization/Plugin/DefaultKeyGeneratorPlugin.php
+++ b/src/Spryker/Service/Synchronization/Plugin/DefaultKeyGeneratorPlugin.php
@@ -38,9 +38,9 @@ class DefaultKeyGeneratorPlugin extends BaseKeyGenerator implements Synchronizat
         $reference = $dataTransfer->getReference() ? $this->keyFilter->escapeKey($dataTransfer->getReference()) : null;
         $localeAndStore = $this->getStoreAndLocaleKey($dataTransfer);
         if ($reference && $localeAndStore) {
-            $keySuffix = sprintf('%s:%s', $this->getStoreAndLocaleKey($dataTransfer), $reference);
+            $keySuffix = sprintf('%s:%s', $localeAndStore, $reference);
         } else {
-            $keySuffix = sprintf('%s%s', $this->getStoreAndLocaleKey($dataTransfer), $reference);
+            $keySuffix = sprintf('%s%s', $localeAndStore, $reference);
         }
 
         return sprintf('%s:%s', $this->getResource(), $keySuffix);


### PR DESCRIPTION
## PR Description

I saw that the function getStoreAndLocaleKey gets called three times for one generateKey call, which i found not necessary as the result is already saved to a variable that can be reused and does not seem to change as the parameter "dataTransfer" is not being modified between calls. 

## Checklist
- [ x ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
